### PR TITLE
Add option to disable RBAC

### DIFF
--- a/cmd/frednode/main.go
+++ b/cmd/frednode/main.go
@@ -73,6 +73,9 @@ type fredConfig struct {
 		Cert string `env:"TRIGGER_CERT"`
 		Key  string `env:"TRIGGER_KEY"`
 	}
+	Auth struct {
+		DisableRBAC bool `env:"AUTH_DISABLE_RBAC"`
+	}
 }
 
 func parseArgs() (fc fredConfig) {
@@ -127,6 +130,9 @@ func parseArgs() (fc fredConfig) {
 	flag.StringVar(&(fc.Trigger.Cert), "trigger-cert", "", "Certificate for trigger node connection. (Env: TRIGGER_CERT)")
 	flag.StringVar(&(fc.Trigger.Key), "trigger-key", "", "Key file for trigger node connection. (Env: TRIGGER_KEY)")
 	flag.Parse()
+
+	// authentication and authorization configuration
+	flag.BoolVar(&(fc.Auth.DisableRBAC), "auth-disable-rbac", false, "Disable RBAC, effectively gives all users all roles. (Env: AUTH_DISABLE_RBAC)")
 
 	// override with ENV variables
 	if err := env.Parse(&fc); err != nil {
@@ -262,6 +268,7 @@ func main() {
 		ExternalHostProxy: fc.Server.Proxy,
 		TriggerCert:       fc.Trigger.Cert,
 		TriggerKey:        fc.Trigger.Key,
+		DisableRBAC:       fc.Auth.DisableRBAC,
 	})
 
 	log.Debug().Msg("Starting Interconnection Server...")

--- a/cmd/frednode/main.go
+++ b/cmd/frednode/main.go
@@ -129,10 +129,11 @@ func parseArgs() (fc fredConfig) {
 	// trigger node tls configuration
 	flag.StringVar(&(fc.Trigger.Cert), "trigger-cert", "", "Certificate for trigger node connection. (Env: TRIGGER_CERT)")
 	flag.StringVar(&(fc.Trigger.Key), "trigger-key", "", "Key file for trigger node connection. (Env: TRIGGER_KEY)")
-	flag.Parse()
 
 	// authentication and authorization configuration
 	flag.BoolVar(&(fc.Auth.DisableRBAC), "auth-disable-rbac", false, "Disable RBAC, effectively gives all users all roles. (Env: AUTH_DISABLE_RBAC)")
+
+	flag.Parse()
 
 	// override with ENV variables
 	if err := env.Parse(&fc); err != nil {

--- a/pkg/fred/auth.go
+++ b/pkg/fred/auth.go
@@ -7,13 +7,15 @@ import (
 )
 
 type authService struct {
-	n NameService
+	n           NameService
+	disableRBAC bool
 }
 
 // newAuthService creates a new authorization service.
-func newAuthService(n NameService) *authService {
+func newAuthService(n NameService, disableRBAC bool) *authService {
 	return &authService{
-		n: n,
+		n:           n,
+		disableRBAC: disableRBAC,
 	}
 }
 
@@ -50,6 +52,11 @@ func (a *authService) revokeRoles(u string, r []Role, k KeygroupName) error {
 
 func (a *authService) isAllowed(u string, m Method, k KeygroupName) (bool, error) {
 	log.Debug().Msgf("checking if user %s is allowed to perform %s on keygroup %s...", u, m, k)
+
+	if a.disableRBAC {
+		return true, nil
+	}
+
 	p, err := a.n.GetUserPermissions(u, k)
 
 	if err != nil {

--- a/pkg/fred/fred.go
+++ b/pkg/fred/fred.go
@@ -17,6 +17,7 @@ type Config struct {
 	NodeID            string
 	TriggerCert       string
 	TriggerKey        string
+	DisableRBAC       bool
 }
 
 // Fred is an instance of FReD.
@@ -84,7 +85,7 @@ func New(config *Config) (f Fred) {
 
 	t := newTriggerService(s, config.TriggerCert, config.TriggerKey)
 
-	a := newAuthService(config.NaSe)
+	a := newAuthService(config.NaSe, config.DisableRBAC)
 
 	return Fred{
 		E: newExthandler(s, r, t, a, config.NaSe),


### PR DESCRIPTION
Adds option for disabling RBAC to allow all user to make any changes to FReD nodes.

For our project (https://github.com/Corgam/LEO-CDN) we need all satellites to be able to add and remove themselves as replicas for any keygroup. At the moment we are using a workaround where we have to ping all satellites in the network in order to find the one that created a keygroup for it to add another satellite. Disabling RBAC would make this process way easier.